### PR TITLE
Use regex to count sip trunks and trunk status.

### DIFF
--- a/checks.d/asteriskpbx.py
+++ b/checks.d/asteriskpbx.py
@@ -74,17 +74,14 @@ class AsteriskCheck(AgentCheck):
         sip_online_trunks = 0
         sip_offline_trunks = 0
 
-        for chan in sip_results:
-            if chan != None:
-                chan_data = chan.split()
+        trunks = re.finditer('^.*-trunk.*([OK|UN].*)', sip_result.data, re.MULTILINE)
 
-                if len(chan_data) > 1:
-                    if "-trunk" in chan_data[0]:
-                        sip_total_trunks += 1
-                        if len(chan_data) > 2 and "OK" in chan_data[5]:
-                            sip_online_trunks += 1
-                        if len(chan_data) > 2 and chan_data[5] == "UNREACHABLE":
-                            sip_offline_trunks += 1
+        for trunk in trunks:
+            sip_total_trunks +=1
+            if 'OK' in trunk.group():
+                sip_online_trunks += 1
+            else:
+                sip_offline_trunks += 1
       
         self.gauge('asterisk.sip.trunks.total',sip_total_trunks)
         self.gauge('asterisk.sip.trunks.online',sip_online_trunks)


### PR DESCRIPTION
Switched to regex from split() because empty columns cause an apparent change in the number of columns.
